### PR TITLE
tests for all api calls

### DIFF
--- a/server.js
+++ b/server.js
@@ -37,7 +37,7 @@ app.get('/api/v1/terms/all', (request, response) => {
 });
 
 //////  GET ALL CATEGORIES  //////
-app.get('/api/v1/categories', (request, response) => {
+app.get('/api/v1/categories/all', (request, response) => {
   database('categories').select()
   .then((categories) => {
     return response.status(200).json(categories);
@@ -187,43 +187,39 @@ app.put('/api/v1/categories/:category_id', async (request, response) => {
 });
 
 //////  DELETE TERM  //////
-app.delete('/api/v1/terms/:terms_id', (request, response) => {
+app.delete('/api/v1/terms/:terms_id', async (request, response) => {
   const { terms_id } = request.params;
 
-  const killedTerm = database('terms').where('id', terms_id).select()
-  if (!killedTerm.length) {
-    return response.status(422).json({ error: `Term ${terms_id} not found` })
-  }
-
-  database('terms').where('id', terms_id).delete()
-  .then(() => {
-    return response.status(204).send({
-      success: `Term ${terms_id} deleted.`
-    })
-  })
-  .catch((error) => {
+  try {
+    const killedTerm = await database('terms').returning('id').where('id', terms_id).delete()
+    if (!killedTerm.length) {
+      return response.status(422).json({ error: `Term ${terms_id} not found` })
+    } else {
+      return response.status(204).json({
+        success: `Term ${terms_id} deleted.`
+      })
+    }
+  } catch (error) {
     return response.status(500).json({ error })
-  });
+  }
 });
 
 //////  DELETE CATEGORY  //////
-app.delete('/api/v1/category/:category_id', (request, response) => {
+app.delete('/api/v1/categories/:category_id', (request, response) => {
   const { category_id } = request.params;
-  const killedCategory = database('categories').where('id', category_id).select()
 
-  if (!killedCategory.length) {
-    return response.status(422).json({ error: `Category ${category_id} not found.` })
-  }
-
-  database('categories').where('id', category_id).delete()
-  .then(() => {
-    return response.status(204).send({
-      success: `Category ${category_id} deleted.`
-    })
-  })
-  .catch((error) => {
+  try {
+    const killedCategory = database('categories').returning('id').where('id', category_id).delete()
+    if (!Object.keys(killedCategory).length) {
+      return response.status(422).json({ error: `Category ${category_id} not found.` })
+    } else {
+      return response.status(204).json({
+        success: `Category ${category_id} deleted.`
+      })
+    }
+  } catch (error) {
     return response.status(500).json({ error })
-  });
+  }
 });
 
 module.exports = app;

--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -38,7 +38,7 @@ describe('API Routes', () => {
 
   it('should get all categories', () => {
     return chai.request(server)
-    .get('/api/v1/categories')
+    .get('/api/v1/categories/all')
     .then(response => {
       response.should.have.status(200);
       response.should.be.json;
@@ -47,13 +47,16 @@ describe('API Routes', () => {
       response.body[0].should.have.property('id');
       response.body[0].should.have.property('name');
     })
+    .catch(error => {
+      throw error;
+    })
   })
 
   it('should get terms by category id', () => {
     let id;
 
     return chai.request(server)
-    .get('/api/v1/categories')
+    .get('/api/v1/categories/all')
     .then(response => {
       id = response.body[0].id;
     })
@@ -71,6 +74,21 @@ describe('API Routes', () => {
         response.body[0].should.have.property('category_id');
         response.body[0].should.have.property('imageURL');   
       })
+    })
+    .catch(error => {
+      throw error;
+    })
+  })
+
+  it('should return a 404 error if category is not found', () => {
+    return chai.request(server)
+    .get('/api/v1/categories/0/terms')
+    .then(response => {
+      response.should.have.status(404);
+      response.should.be.json;
+    })
+    .catch(error => {
+      throw error;
     })
   })
 
@@ -91,6 +109,21 @@ describe('API Routes', () => {
       response.body[0].definition.should.equal('Receptors located in nose and are chemoreceptors for smell.  Primarily for detection hedonic for modulation and for emotional memory support for detail/discrimination.')
       response.body[0].category_name.should.equal('Sensory Systems');
       response.body[0].imageURL.should.equal('');
+    })
+    .catch(error => {
+      throw error;
+    })
+  })
+
+  it('should return a 404 error when term is not found', () => {
+    return chai.request(server)
+    .get('/api/v1/terms?term=pants')
+    .then(response => {
+      response.should.have.status(404);
+      response.should.be.json;
+    })
+    .catch(error => {
+      throw error;
     })
   })
     
@@ -121,6 +154,264 @@ describe('API Routes', () => {
         response.body[0].category_name.should.equal('Sensory Systems');
         response.body[0].imageURL.should.equal('');
       })
+    })
+    .catch(error => {
+      throw error;
+    })
+  })
+
+  it('should return a 404 error when term id is not found', () => {
+    return chai.request(server)
+    .get('/api/v1/terms/0')
+    .then(response => {
+      response.should.have.status(404);
+      response.should.be.json;
+    })
+    .catch(error => {
+      throw error;
+    })
+  })
+
+  it('should create a new term', () => {
+    let id;
+
+    return chai.request(server)
+    .get('/api/v1/categories/all')
+    .then(response => {
+      id = response.body[0].id;
+    })
+    .then(() => {
+      return chai.request(server)
+      .post(`/api/v1/categories/${id}/terms`)
+      .send({
+        term: "New Term",
+        definition: "This is my definition"
+      })
+      .then(response => {
+        response.should.have.status(201);
+        response.should.be.json;
+        response.body.should.be.a('array');
+      })
+      .catch(error => {
+        throw error;
+      })
+    })
+    .catch(error => {
+      throw error;
+    })
+  })
+
+  it('should return a 404 error if category is not found when creating a term', () => {
+    return chai.request(server)
+    .post('/api/v1/categories/0/terms')
+    .send({
+      term: "New Term",
+      definition: "This is my definition"
+    })
+    .then(response => {
+      response.should.have.status(404);
+      response.should.be.json;
+    })
+    .catch(error => {
+      throw error;
+    })
+  })
+
+  it('should return a 422 error if parameters are missing', () => {
+    let id;
+
+    return chai.request(server)
+    .get('/api/v1/categories/all')
+    .then(response => {
+      id = response.body[0].id;
+    })
+    .then(() => {
+      return chai.request(server)
+      .post(`/api/v1/categories/${id}/terms`)
+      .send({
+        term: "New Term"
+      })
+      .then(response => {
+        response.should.have.status(422);
+        response.should.be.json;
+      })
+      .catch(error => {
+        throw error;
+      })
+    })
+    .catch(error => {
+      throw error;
+    })
+  })
+
+  it('should create a new category', () => {
+    return chai.request(server)
+    .post('/api/v1/categories')
+    .send({
+      name: "New Category"
+    })
+    .then(response => {
+      response.should.have.status(201)
+      response.should.be.json;
+    })
+    .catch(error => {
+      throw error;
+    })
+  })
+
+  it('should return a 422 error if parameters are missing', () => {
+    return chai.request(server)
+    .post('/api/v1/categories')
+    .then(response => {
+      response.should.have.status(422)
+      response.should.be.json;
+    })
+    .catch(error => {
+      throw error;
+    })
+  })
+
+  it('should update a term', () => {
+    let id;
+
+    return chai.request(server)
+    .get('/api/v1/terms/all')
+    .then(response => {
+      id = response.body[0].id;
+    })
+    .then(() => {
+      return chai.request(server)
+      .put(`/api/v1/terms/${id}`)
+      .send({
+        definition: "Look I have a new definition!"
+      })
+      .then(response => {
+        response.should.have.status(201);
+        response.should.be.json;
+        response.body.success.should.equal(`Term ${id} updated.`);
+      })
+      .catch(error => {
+        throw error;
+      })
+    })
+    .catch(error => {
+      throw error;
+    })
+  })
+
+  it('should return a 422 error when terms id is not found', () => {
+    return chai.request(server)
+    .put('/api/v1/terms/0')
+    .send({
+      definition: "Look I have a new definition!"
+    })
+    .then(response => {
+      response.should.have.status(422);
+      response.should.be.json;
+    })
+    .catch(error => {
+      throw error;
+    })
+  })
+
+  it('should update a category', () => {
+    let id;
+
+    return chai.request(server)
+    .get('/api/v1/categories/all')
+    .then(response => {
+      id = response.body[0].id;
+    })
+    .then(() => {
+      return chai.request(server)
+      .put(`/api/v1/categories/${id}`)
+      .send({
+        name: 'Look I have a new name!'
+      })
+      .then(response => {
+        response.should.have.status(201);
+        response.should.be.json;
+        response.body.success.should.equal(`Category ${id} updated.`);
+      })
+      .catch(error => {
+        throw error;
+      })
+    })
+    .catch(error => {
+      throw error;
+    })
+  })
+
+  it('should return a 422 error when category is not found', () => {
+    return chai.request(server)
+    .put('/api/v1/categories/0')
+    .send({
+      name: 'Look I have a new name!'
+    })
+    .then(response => {
+      response.should.have.status(422);
+      response.should.be.json;
+    })
+    .catch(error => {
+      throw error;
+    })
+  })
+
+  it('should delete a term', () => {
+    let id;
+
+    return chai.request(server)
+    .get('/api/v1/terms/all')
+    .then(response => {
+      id = response.body[0].id;
+    })
+    .then(() => {
+      return chai.request(server)
+      .delete(`/api/v1/terms/${id}`)
+      .then(response => {
+        response.should.have.status(204);
+      })
+    })
+    .catch(error => {
+      throw error;
+    })
+  })
+
+  it('should return a 422 error when term is not found', () => {
+    return chai.request(server)
+    .delete('/api/v1/terms/0')
+    .catch(response => {
+      response.should.have.status(422);
+      response.should.be.json;
+    })
+  })
+
+  it('should delete a category', () => {
+    let id;
+
+    return chai.request(server)
+    .get('/api/v1/categories/all')
+    .then(response => {
+      id = response.body[0].id;
+    })
+    .then(() => {
+      return chai.request(server)
+      .delete(`/api/v1/categories/${id}`)
+      .then(response => {
+        response.should.have.status(204);
+      })
+    })
+    .catch(error => {
+      throw error;
+    })
+  })
+
+  it('should return a 422 error when category is not found', () => {
+    return chai.request(server)
+    .delete('/api/v1/categories/0')
+    .catch(error => {
+      error.should.have.status(422);
+      response.should.be.json;
     })
   })
 


### PR DESCRIPTION
Add happy/sad path tests for PUT requests
Add happy/sad path tests for DELETE requests
Add happy/sad path tests for POST requests
Update GET requests to use try/catch and query database only once
Update DELETE requests to use try/catch and query database only once